### PR TITLE
Require map! and foreach to take a TSC as their first source argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ notifications:
 git:
   depth: 99999999
 
+# matrix:
+#   allow_failures:
+#     - julia: nightly
+
 ## uncomment and modify the following lines to manually install system packages
 #addons:
 #  apt: # apt-get for linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ notifications:
 git:
   depth: 99999999
 
-matrix:
-  allow_failures:
-    - julia: nightly
-
 ## uncomment and modify the following lines to manually install system packages
 #addons:
 #  apt: # apt-get for linux


### PR DESCRIPTION
This makes map! and foreach slightly less useful, but it's a simple way
to fix #19 on Julia master.

The more correct solution would be to implement something like the way
BroadcastStyle works for broadcast(), but that's a much bigger change.

I've also, somewhat optimistically, removed the `allow_failures: nightly` from Travis. We'll see how that goes. 