### PR TITLE
Don't extend Base.indices (deprecated)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,18 @@
 language: julia
 os:
   - linux
-  # - osx
 julia:
-  # - 0.6
+  - 0.7
+  - 1.0
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 branches:
   only:
     - master
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 notifications:
   email: false
-git:
-  depth: 99999999
-
-# matrix:
-#   allow_failures:
-#     - julia: nightly
-
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
-
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("TypeSortedCollections"); Pkg.test("TypeSortedCollections"; coverage=true)'
 after_success:
- - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+- julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ julia> map!(*, results, sortedxs, sortedys) # Error!
 ```
 The error happens because `xs` and `ys` don't have the same number of different element types. This problem can be solved by aligning the indices of `sortedys` with those of `sortedxs`:
 ```julia
-julia> sortedys = TypeSortedCollection(ys, indices(sortedxs));
+julia> sortedys = TypeSortedCollection(ys, TypeSortedCollections.indices(sortedxs));
 
 julia> map!(*, results, sortedxs, sortedys)
 4-element Array{Float64,1}:

--- a/src/TypeSortedCollections.jl
+++ b/src/TypeSortedCollections.jl
@@ -129,7 +129,7 @@ const TSCOrAbstractVector{N} = Union{<:TypeSortedCollection{<:Any, N}, AbstractV
 Base.isempty(x::TypeSortedCollection) = all(isempty, x.data)
 Base.empty!(x::TypeSortedCollection) = foreach(empty!, x.data)
 @inline Base.length(x::TypeSortedCollection) = mapreduce(length, +, x.data, init=0)
-Base.indices(x::TypeSortedCollection) = x.indices # semantics are a little different from Array, but OK
+indices(x::TypeSortedCollection) = x.indices
 
 # Trick from StaticArrays:
 @inline first_tsc(a1::TypeSortedCollection, as...) = a1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 using TypeSortedCollections
 
+using TypeSortedCollections: indices
+
 module M
 f(x::Int64) = 3 * x
 f(x::Float64) = round(Int64, x / 2)


### PR DESCRIPTION
Instead just have a separate (unexported) function. Unexported to avoid confusion with the old `Base.indices`.