### PR TITLE
Fully drop 0.7 support.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.7-alpha
-Compat 0.33 # for Compat.Test
+julia 1.0

--- a/src/TypeSortedCollections.jl
+++ b/src/TypeSortedCollections.jl
@@ -1,5 +1,3 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module TypeSortedCollections
 
 export
@@ -7,8 +5,6 @@ export
     num_types,
     eltypes,
     vectortypes
-
-using Compat
 
 const TupleOfVectors = Tuple{Vararg{Vector{T} where T}}
 


### PR DESCRIPTION
Needed because of ambiguities with deprecated methods on 0.7:

```julia
 (any(f::F, tsc::TypeSortedCollection{#s16,N} where #s16) where {F, N} in TypeSortedCollections at /home/twan/.julia/dev/TypeSortedCollections/src/TypeSortedCollections.jl:224, any(a::AbstractArray, dims) in Base at deprecated.jl:53)
 (all(f::F, tsc::TypeSortedCollection{#s16,N} where #s16) where {F, N} in TypeSortedCollections at /home/twan/.julia/dev/TypeSortedCollections/src/TypeSortedCollections.jl:244, all(a::AbstractArray, dims) in Base at deprecated.jl:53)
```

Also lose Compat dependency.